### PR TITLE
add tracing to genode code

### DIFF
--- a/src/log/client/genode/log_client.cc
+++ b/src/log/client/genode/log_client.cc
@@ -4,6 +4,9 @@
 #include <log_session/connection.h>
 #include <cai_capability.h>
 
+//#define ENABLE_TRACE
+#include <trace.h>
+
 namespace Cai
 {
 #include <log_client.h>
@@ -19,6 +22,7 @@ struct Log_session
     Log_session(Genode::Env &env, const char *label) :
         _log(env, label)
     {
+        TLOG("label=", label);
         Genode::memset(_buffer, 0, sizeof(_buffer));
     }
 };
@@ -29,11 +33,13 @@ Cai::Log::Client::Client() :
 
 bool Cai::Log::Client::initialized()
 {
+    TLOG();
     return (bool)_session;
 }
 
 void Cai::Log::Client::initialize(void *env, const char *label)
 {
+    TLOG("env=", env, " label=", label);
     check_factory(_factory, *reinterpret_cast<Cai::Env *>(env)->env);
     _session = _factory->create<Log_session>(
             *reinterpret_cast<Cai::Env *>(env)->env,
@@ -42,17 +48,20 @@ void Cai::Log::Client::initialize(void *env, const char *label)
 
 void Cai::Log::Client::finalize()
 {
+    TLOG();
     _factory->destroy<Log_session>(_session);
     _session = nullptr;
 }
 
 static Log_session *log(void *session)
 {
+    TLOG("session=", session);
     return static_cast<Log_session *>(session);
 }
 
 void Cai::Log::Client::write(const char *message)
 {
+    TLOG("message=", message);
     if(Genode::strlen(log(_session)->_buffer) < Log_session::WRITE_BUFFER){
         Genode::memcpy(&(log(_session)->_buffer[Genode::strlen(log(_session)->_buffer)]),
                        message,
@@ -68,12 +77,14 @@ void Cai::Log::Client::write(const char *message)
 
 void Cai::Log::Client::flush()
 {
+    TLOG();
     log(_session)->_log.write(log(_session)->_buffer);
     Genode::memset(log(_session)->_buffer, 0, sizeof(Log_session::_buffer));
 }
 
 Genode::uint64_t Cai::Log::Client::maximum_message_length()
 {
+    TLOG();
     static_assert(Genode::Log_session::MAX_STRING_LEN - 16 > 79);
     return Genode::Log_session::MAX_STRING_LEN - 16;
 }

--- a/src/platform/genode/cai_main.cc
+++ b/src/platform/genode/cai_main.cc
@@ -3,6 +3,9 @@
 #include <base/signal.h>
 #include <cai_capability.h>
 
+//#define ENABLE_TRACE
+#include <trace.h>
+
 Genode::Env *__genode_env; // only required for ada-runtime
 
 extern "C" void adainit();
@@ -17,6 +20,7 @@ struct Main
 
     void exit_handler()
     {
+        TLOG();
         _cai_env.destruct();
         adafinal();
         _cai_env.env->parent().exit(_cai_env.status);
@@ -26,6 +30,7 @@ struct Main
         _env(env),
         _exit(env.ep(), *this, &Main::exit_handler)
     {
+        TLOG();
         adainit();
         componolit_interfaces_component_construct(&_cai_env);
     }

--- a/src/platform/genode/trace.h
+++ b/src/platform/genode/trace.h
@@ -1,0 +1,20 @@
+
+#ifndef _GNEISS_GENODE_TRACE_H_
+#define _GNEISS_GENODE_TRACE_H_
+
+#ifdef ENABLE_TRACE
+
+#include <base/log.h>
+#define TLOG(...) Genode::log(__FILE__, ":", __LINE__," (", __func__, "): ",##__VA_ARGS__)
+#define TWRN(...) Genode::warning(__FILE__, ":", __LINE__," (", __func__, "): ",##__VA_ARGS__)
+#define TERR(...) Genode::error(__FILE__, ":", __LINE__," (", __func__, "): ",##__VA_ARGS__)
+
+#else
+
+#define TLOG(...)
+#define TWRN(...)
+#define TERR(...)
+
+#endif
+
+#endif /* ifndef _GNEISS_GENODE_TRACE_H_ */

--- a/src/rom/client/genode/configuration_client.cc
+++ b/src/rom/client/genode/configuration_client.cc
@@ -6,6 +6,9 @@
 #include <factory.h>
 #include <cai_capability.h>
 
+//#define ENABLE_TRACE
+#include <trace.h>
+
 class Config
 {
     private:
@@ -32,12 +35,14 @@ Config::Config(Cai::Env *env, void (*parse)(void const *, Genode::uint64_t), con
     _sigh(env->env->ep(), *this, &Config::update),
     _parse(parse)
 {
+    TLOG("env=", env, " parse=", parse, " label=", label);
     _ds.sigh(_sigh);
     _ds.update();
 }
 
 void Config::update()
 {
+    TLOG();
     _ds.update();
     try{
         Genode::Xml_node raw = _ds.xml().sub_node();
@@ -49,10 +54,13 @@ void Config::update()
 
 Cai::Configuration::Client::Client() :
     _config(nullptr)
-{ }
+{
+    TLOG();
+}
 
 void Cai::Configuration::Client::initialize(void *env, void *parse, const char *label)
 {
+    TLOG("env=", env, " parse=", parse, " label=", label);
     check_factory(_factory, *reinterpret_cast<Cai::Env *>(env)->env);
     _config = _factory->create<Config>(reinterpret_cast<Cai::Env *>(env),
                                        reinterpret_cast<void (*)(void const *, Genode::uint64_t)>(parse),
@@ -61,16 +69,19 @@ void Cai::Configuration::Client::initialize(void *env, void *parse, const char *
 
 bool Cai::Configuration::Client::initialized()
 {
+    TLOG();
     return _config;
 }
 
 void Cai::Configuration::Client::load()
 {
+    TLOG();
     reinterpret_cast<Config *>(_config)->update();
 }
 
 void Cai::Configuration::Client::finalize()
 {
+    TLOG();
     _factory->destroy<Config>(_config);
     _config = nullptr;
 }


### PR DESCRIPTION
When debugging Gneiss on Genode I often encountered the issue that I had to insert tracing manually into the file I wanted to debug and especially had to remove it afterwards. This PR adds a simple tracing that can be enabled per file and logs function calls with their arguments by default.