### PR TITLE
Callback read and write in interface for block server

### DIFF
--- a/src/block/server/componolit-gneiss-block-server.ads
+++ b/src/block/server/componolit-gneiss-block-server.ads
@@ -175,8 +175,10 @@ is
    --
    --  @param S  Server session instance
    --  @param R  Request to handle
+   --  @param I  Application defined identifier of the request
    procedure Read (S : in out Server_Session;
-                   R :        Request) with
+                   R :        Request;
+                   I :        Request_Id) with
       Pre  => Ready (S)
               and then Initialized (S)
               and then Status (R) = Pending
@@ -208,8 +210,10 @@ is
    --
    --  @param S  Server session instance
    --  @param R  Request to handle
+   --  @param I  Application defined identifier of the request
    procedure Write (S : in out Server_Session;
-                    R :        Request) with
+                    R :        Request;
+                    I :        Request_Id) with
       Pre  => Ready (S)
               and then Initialized (S)
               and then Status (R) = Pending

--- a/src/block/server/componolit-gneiss-block-server.ads
+++ b/src/block/server/componolit-gneiss-block-server.ads
@@ -60,6 +60,27 @@ generic
    --  @param S  Server session instance identifier
    with procedure Finalize (S : in out Server_Session);
 
+   --  Called when a read has been triggered and data to read is needed
+   --
+   --  The length of Data always corresponds to the request length in bytes (block size * block count)
+   --
+   --  @param S       Server session instance
+   --  @param Req     Request identifier of request to write
+   --  @param Data    Data to read
+   with procedure Read (S    : in out Server_Session;
+                        Req  :        Request_Id;
+                        Data :    out Buffer);
+
+   --  Called when a write has been triggered and data to write is available
+   --
+   --  The length of Data always corresponds to the request length in bytes (block size * block count)
+   --
+   --  @param S       Server session instance
+   --  @param Req     Request identifier of request to write
+   --  @param Data    Data to write
+   with procedure Write (S    : in out Server_Session;
+                         Req  :        Request_Id;
+                         Data :        Buffer);
    pragma Warnings (On, "* is not referenced");
 package Componolit.Gneiss.Block.Server with
    SPARK_Mode
@@ -150,6 +171,21 @@ is
               and then Initialized (S)
               and then Assigned (S, R);
 
+   --  Call Read callback to provide data to read
+   --
+   --  @param S  Server session instance
+   --  @param R  Request to handle
+   procedure Read (S : in out Server_Session;
+                   R :        Request) with
+      Pre  => Ready (S)
+              and then Initialized (S)
+              and then Status (R) = Pending
+              and then Kind (R)   = Read
+              and then Assigned (S, R),
+      Post => Ready (S)
+              and then Initialized (S)
+              and then Assigned (S, R);
+
    --  Get the data of a write request that shall be written
    --
    --  @param S  Server session instance
@@ -163,6 +199,21 @@ is
               and then Status (R) = Pending
               and then Kind (R)   = Write
               and then B'Length   = Length (R) * Block_Size (S)
+              and then Assigned (S, R),
+      Post => Ready (S)
+              and then Initialized (S)
+              and then Assigned (S, R);
+
+   --  Call Write callback to provide data to write
+   --
+   --  @param S  Server session instance
+   --  @param R  Request to handle
+   procedure Write (S : in out Server_Session;
+                    R :        Request) with
+      Pre  => Ready (S)
+              and then Initialized (S)
+              and then Status (R) = Pending
+              and then Kind (R)   = Write
               and then Assigned (S, R),
       Post => Ready (S)
               and then Initialized (S)

--- a/src/block/server/componolit-gneiss-block-server.ads
+++ b/src/block/server/componolit-gneiss-block-server.ads
@@ -320,4 +320,34 @@ private
                     "ghost procedure ""Lemma_Finalize"" cannot have non-ghost global output *",
                     "This procedure is only used to enforce the precondition of Dispatch");
 
+   --  Lemma for Read to check function contracts of generic parameter
+   --
+   --  @param S  Server session instance
+   --  @param R  Request identifier of request to write
+   --  @param D  Data to read
+   procedure Lemma_Read (S : in out Server_Session;
+                         R :        Request_Id;
+                         D :    out Buffer) with
+      Ghost,
+      Pre => Ready (S);
+
+   pragma Annotate (GNATprove, False_Positive,
+                    "ghost procedure ""Lemma_Read"" cannot have non-ghost global output *",
+                    "This procedure is only used to enforce the precondition of Dispatch");
+
+   --  Lemma for Write to check function contracts of generic parameter
+   --
+   --  @param S  Server session instance
+   --  @param R  Request identifier of request to write
+   --  @param D  Data to write
+   procedure Lemma_Write (S : in out Server_Session;
+                          R :        Request_Id;
+                          D :        Buffer) with
+      Ghost,
+      Pre => Ready (S);
+
+   pragma Annotate (GNATprove, False_Positive,
+                    "ghost procedure ""Lemma_Write"" cannot have non-ghost global output *",
+                    "This procedure is only used to enforce the precondition of Dispatch");
+
 end Componolit.Gneiss.Block.Server;

--- a/src/block/server/genode/block_server.cc
+++ b/src/block/server/genode/block_server.cc
@@ -165,6 +165,16 @@ void Cai::Block::Server::write(void *request, void *buffer)
     });
 }
 
+void Cai::Block::Server::read_write(void *request, Genode::uint32_t id,
+                                    void (*rw)(void *, Genode::uint32_t, void *, Genode::uint64_t))
+{
+    TLOG("request=", request, "id=", id);
+    ::Block::Request *req = reinterpret_cast<::Block::Request *>(request);
+    blk(_session).with_content(*req, [&] (void *ptr, Genode::size_t size){
+        rw((void *)this, id, ptr, size);
+    });
+}
+
 void Cai::Block::Server::acknowledge(void *request, int *success)
 {
     TLOG("request=", request, " success=", success);

--- a/src/block/server/genode/block_server.h
+++ b/src/block/server/genode/block_server.h
@@ -35,6 +35,8 @@ namespace Block
             void process_request(void *request, int *success);
             void read(void *request, void *buffer);
             void write(void *request, void *buffer);
+            void read_write(void *request, Genode::uint32_t id,
+                            void (*rw)(void *, Genode::uint32_t, void *, Genode::uint64_t));
             void acknowledge(void *request, int *success);
             void unblock_client();
     };

--- a/src/block/server/genode/componolit-gneiss-block-server.adb
+++ b/src/block/server/genode/componolit-gneiss-block-server.adb
@@ -112,7 +112,7 @@ is
    begin
       Cxx.Block.Server.Read_Write (S.Instance,
                                    R.Request,
-                                   Cxx.Genode.Uint32_T (Request_Id'Pos (I)), --  FIXME: correct conversion
+                                   Request_Id'Pos (I),
                                    Async_Read'Address);
    end Read;
 
@@ -124,7 +124,7 @@ is
    begin
       Cxx.Block.Server.Read_Write (S.Instance,
                                    R.Request,
-                                   Cxx.Genode.Uint32_T (Request_Id'Pos (I)), --  FIXME: correct conversion
+                                   Request_Id'Pos (I),
                                    Async_Write'Address);
    end Write;
 

--- a/src/block/server/genode/componolit-gneiss-block-server.adb
+++ b/src/block/server/genode/componolit-gneiss-block-server.adb
@@ -160,4 +160,20 @@ is
       Finalize (S);
    end Lemma_Finalize;
 
+   procedure Lemma_Read (S : in out Server_Session;
+                         R :        Request_Id;
+                         D :    out Buffer)
+   is
+   begin
+      Read (S, R, D);
+   end Lemma_Read;
+
+   procedure Lemma_Write (S : in out Server_Session;
+                          R :        Request_Id;
+                          D :        Buffer)
+   is
+   begin
+      Write (S, R, D);
+   end Lemma_Write;
+
 end Componolit.Gneiss.Block.Server;

--- a/src/block/server/genode/componolit-gneiss-block-server.adb
+++ b/src/block/server/genode/componolit-gneiss-block-server.adb
@@ -1,4 +1,5 @@
 
+with System;
 with Cxx.Genode;
 with Cxx.Block.Server;
 use all type Cxx.Bool;
@@ -67,6 +68,64 @@ is
       Cxx.Block.Server.Write (S.Instance,
                               R.Request,
                               B'Address);
+   end Write;
+
+   procedure Async_Read (S : in out Server_Session;
+                         R :        Request_Id;
+                         D :        System.Address;
+                         L :        Buffer_Index);
+
+   procedure Async_Read (S : in out Server_Session;
+                         R :        Request_Id;
+                         D :        System.Address;
+                         L :        Buffer_Index)
+   is
+      B : Buffer (1 .. L) with
+         Import,
+         Address => D;
+   begin
+      Read (S, R, B);
+   end Async_Read;
+
+   procedure Async_Write (S : in out Server_Session;
+                          R :        Request_Id;
+                          D :        System.Address;
+                          L :        Buffer_Index);
+
+   procedure Async_Write (S : in out Server_Session;
+                          R :        Request_Id;
+                          D :        System.Address;
+                          L :        Buffer_Index)
+   is
+      B : Buffer (1 .. L) with
+         Import,
+         Address => D;
+   begin
+      Write (S, R, B);
+   end Async_Write;
+
+   procedure Read (S : in out Server_Session;
+                   R :        Request;
+                   I :        Request_Id) with
+      SPARK_Mode => Off
+   is
+   begin
+      Cxx.Block.Server.Read_Write (S.Instance,
+                                   R.Request,
+                                   Cxx.Genode.Uint32_T (Request_Id'Pos (I)), --  FIXME: correct conversion
+                                   Async_Read'Address);
+   end Read;
+
+   procedure Write (S : in out Server_Session;
+                    R :        Request;
+                    I :        Request_Id) with
+      SPARK_Mode => Off
+   is
+   begin
+      Cxx.Block.Server.Read_Write (S.Instance,
+                                   R.Request,
+                                   Cxx.Genode.Uint32_T (Request_Id'Pos (I)), --  FIXME: correct conversion
+                                   Async_Write'Address);
    end Write;
 
    procedure Acknowledge (S   : in out Server_Session;

--- a/src/block/server/genode/cxx-block-server.ads
+++ b/src/block/server/genode/cxx-block-server.ads
@@ -76,6 +76,15 @@ is
       Convention    => CPP,
       External_Name => "_ZN3Cai5Block6Server5writeEPvS2_";
 
+   procedure Read_Write (This   : Class;
+                         Req    : Request;
+                         Id     : Cxx.Genode.Uint32_T;
+                         Buffer : Cxx.Void_Address) with
+      Global        => null,
+      Import,
+      Convention    => CPP,
+      External_Name => "_ZN3Cai5Block6Server10read_writeEPvjPFvS2_jS2_yE";
+
    procedure Acknowledge (This   :        Class;
                           Req    : in out Request;
                           Status : in out Integer) with

--- a/src/block/server/muen/componolit-gneiss-block-server.adb
+++ b/src/block/server/muen/componolit-gneiss-block-server.adb
@@ -196,5 +196,21 @@ is
       Finalize (S);
    end Lemma_Finalize;
 
+   procedure Lemma_Read (S : in out Server_Session;
+                         R :        Request_Id;
+                         D :    out Buffer)
+   is
+   begin
+      Read (S, R, D);
+   end Lemma_Read;
+
+   procedure Lemma_Write (S : in out Server_Session;
+                          R :        Request_Id;
+                          D :        Buffer)
+   is
+   begin
+      Write (S, R, D);
+   end Lemma_Write;
+
    pragma Warnings (On);
 end Componolit.Gneiss.Block.Server;

--- a/test/block_proxy/component.adb
+++ b/test/block_proxy/component.adb
@@ -303,4 +303,25 @@ package body Component is
        and then Block.Block_Count (Client) > 0
        and then Block.Block_Count (Client) < Block.Count'Last / (Block.Count (Block.Block_Size (Client)) / 512));
 
+   procedure Write (S : in out Block.Server_Session;
+                    I :        Request_Index;
+                    D :        Buffer)
+   is
+      pragma Unreferenced (S);
+      pragma Unreferenced (I);
+      pragma Unreferenced (D);
+   begin
+      null;
+   end Write;
+
+   procedure Read (S : in out Block.Server_Session;
+                   I :        Request_Index;
+                   D :    out Buffer)
+   is
+      pragma Unreferenced (S);
+      pragma Unreferenced (I);
+   begin
+      D := (others => 0);
+   end Read;
+
 end Component;

--- a/test/block_proxy/component.ads
+++ b/test/block_proxy/component.ads
@@ -55,13 +55,23 @@ package Component is
    function Writable (S : Block.Server_Session) return Boolean with
       Pre => Initialized (S);
 
+   procedure Write (S : in out Block.Server_Session;
+                    I :        Request_Index;
+                    D :        Buffer);
+
+   procedure Read (S : in out Block.Server_Session;
+                   I :        Request_Index;
+                   D :    out Buffer);
+
    package Block_Server is new Block.Server (Event,
                                              Block_Count,
                                              Block_Size,
                                              Writable,
                                              Initialized,
                                              Initialize_Server,
-                                             Finalize_Server);
+                                             Finalize_Server,
+                                             Read,
+                                             Write);
    package Block_Dispatcher is new Block.Dispatcher (Block_Server, Dispatch);
 
 end Component;

--- a/test/block_server/component.ads
+++ b/test/block_server/component.ads
@@ -44,13 +44,23 @@ is
                       C :        Block.Dispatcher_Capability) with
       Pre => Block.Initialized (I) and then not Block.Accepted (I);
 
+   procedure Read (S : in out Block.Server_Session;
+                   R :        Request_Index;
+                   B :    out Buffer);
+
+   procedure Write (S : in out Block.Server_Session;
+                    R :        Request_Index;
+                    B :        Buffer);
+
    package Block_Server is new Block.Server (Event,
                                              Block_Count,
                                              Block_Size,
                                              Writable,
                                              Initialized,
                                              Initialize,
-                                             Finalize);
+                                             Finalize,
+                                             Read,
+                                             Write);
    package Block_Dispatcher is new Block.Dispatcher (Block_Server, Request);
 
 end Component;


### PR DESCRIPTION
Implementation of the callback interface defined in #104. The proof of the block server test is now broken. Also the conversion of the request id is still unproven (but is so in all other implementations, too). The general problem is addressed in #112.